### PR TITLE
[api fix] Expose jsdom from `require(setup-env/jsdom);`

### DIFF
--- a/jsdom.js
+++ b/jsdom.js
@@ -55,11 +55,16 @@ module.exports = function jsdomMount({ debug, config, ignore }) {
     url: 'http://localhost'
   }, config.jsdom));
 
-  const { window } = page;
+  //
+  // Alias the jsdom reference onto this module for easy
+  // require / import in tests when necessary.
+  //
+  module.exports.jsdom = page;
 
   //
   // Introduce the variables to the global scope.
   //
+  const { window } = page;
   global.window = window;
   global.document = window.document;
   global.navigator = {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -65,6 +65,11 @@ describe('setup-env', function () {
       assume(global.navigator).is.not.a('undefined');
     });
 
+    it('aliases the jsdom instance', function () {
+      const { jsdom } = require('../jsdom');
+      assume(jsdom.reconfigure).is.a('function');
+    });
+
     it('uses the localhost instead of about:blank', function () {
       assume(location.href).equals('http://localhost/');
     });


### PR DESCRIPTION
`JSDOM.changeUrl` was removed in `jsdom@10.0.0`. The same such functionality now only exists on the `jsdom` instance. Due to this change we need a way to expose this to the instance that . `setup-env` creates to the downstream consumers when they need it.