### PR TITLE
fix: switch load order to avoid breaking events

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,8 +55,8 @@ const config = Object.assign({
   steps: [
     'env',          // Prepare the NODE_ENV.
     'register',     // Setup @babel/register.
-    'enzyme',       // Configure enzyme Adapter.
     'jsdom',        // Prepare enviroment for { mount } support.
+    'enzyme',       // Configure enzyme Adapter.
     'static',       // Allow require of static assets in Node.js.
     'assert'        // Introduce plugins to assert frameworks.
   ],


### PR DESCRIPTION
Ran into this while migrating from enzyme to RTL. If enzyme in imported before jsdom is initialized it breaks dom events. Enzyme's event simulation still seems to work because it is deeper in the react internals.

https://stackoverflow.com/questions/61371194/react-trying-to-attachevents-under-jsdom